### PR TITLE
Support mult-chain wallets in get_metadata calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - <PR-#ISSUE> ...
 
+## `0.1.0` - 11/30/2022
+
+#### Added
+
+- PR-#46: Support mult-chain wallets in get_metadata calls
+
 ## `0.0.5` - 06/23/2021
 
 #### Fixed

--- a/magic_admin/resources/__init__.py
+++ b/magic_admin/resources/__init__.py
@@ -1,2 +1,3 @@
 from magic_admin.resources.token import Token
 from magic_admin.resources.user import User
+from magic_admin.resources.wallet import WalletType

--- a/magic_admin/resources/user.py
+++ b/magic_admin/resources/user.py
@@ -1,4 +1,5 @@
 from magic_admin.resources.base import ResourceComponent
+from magic_admin.resources.wallet import WalletType
 from magic_admin.utils.did_token import construct_issuer_with_public_address
 
 
@@ -7,8 +8,22 @@ class User(ResourceComponent):
     v1_user_info = '/v1/admin/auth/user/get'
     v2_user_logout = '/v2/admin/auth/user/logout'
 
+    def get_metadata_by_issuer_and_wallet(self, issuer, wallet_type):
+        return self.request(
+            'get', self.v1_user_info, params={'issuer': issuer, 'wallet_type': wallet_type},
+        )
+
+    def get_metadata_by_public_address_and_wallet(self, public_address, wallet_type):
+        return self.get_metadata_by_issuer_and_wallet(
+            construct_issuer_with_public_address(public_address),
+            wallet_type,
+        )
+
+    def get_metadata_by_token_and_wallet(self, did_token, wallet_type):
+        return self.get_metadata_by_issuer_and_wallet(self.Token.get_issuer(did_token), wallet_type)
+
     def get_metadata_by_issuer(self, issuer):
-        return self.request('get', self.v1_user_info, params={'issuer': issuer})
+        return self.get_metadata_by_issuer_and_wallet(issuer, WalletType.NONE)
 
     def get_metadata_by_public_address(self, public_address):
         return self.get_metadata_by_issuer(

--- a/magic_admin/resources/wallet.py
+++ b/magic_admin/resources/wallet.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class WalletType(Enum):
+    ETH = 'ETH'
+    HARMONY = 'HARMONY'
+    ICON = 'ICON'
+    FLOW = 'FLOW'
+    TEZOS = 'TEZOS'
+    ZILLIQA = 'ZILLIQA'
+    POLKADOT = 'POLKADOT'
+    SOLANA = 'SOLANA'
+    AVAX = 'AVAX'
+    ALGOD = 'ALGOD'
+    COSMOS = 'COSMOS'
+    CELO = 'CELO'
+    BITCOIN = 'BITCOIN'
+    NEAR = 'NEAR'
+    HELIUM = 'HELIUM'
+    CONFLUX = 'CONFLUX'
+    TERRA = 'TERRA'
+    TAQUITO = 'TAQUITO'
+    ED = 'ED'
+    HEDERA = 'HEDERA'
+    NONE = 'NONE'
+    ANY = 'ANY'

--- a/magic_admin/version.py
+++ b/magic_admin/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.0.5'
+VERSION = '0.1.0'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,7 @@ pexpect==4.8.0
 pickleshare==0.7.5
 pluggy==0.13.1
 pre-commit==1.21.0
+pretend==1.0.8
 prompt-toolkit==3.0.5
 ptyprocess==0.6.0
 py==1.8.1
@@ -27,6 +28,7 @@ Pygments==2.6.1
 pyparsing==2.4.7
 pytest==5.4.1
 pytest-cov==2.8.1
+pytest-mock==3.6.1
 PyYAML==5.3.1
 six==1.14.0
 toml==0.10.0

--- a/tests/unit/resources/user_test.py
+++ b/tests/unit/resources/user_test.py
@@ -1,120 +1,205 @@
 from unittest import mock
+from unittest.mock import sentinel
 
 import pytest
+from pretend import stub
 
 from magic_admin.resources.user import User
+from magic_admin.resources.wallet import WalletType
 from testing.data.did_token import future_did_token
-from testing.data.did_token import issuer
 from testing.data.did_token import public_address
 
 
 class TestUser:
 
+    metadata_with_wallets = stub(
+        data=stub(
+            email=sentinel.email,
+            issuer=sentinel.issuer,
+            public_address=sentinel.public_address,
+            wallets=[
+                stub(
+                    network=sentinel.network,
+                    wallet_type=WalletType.ETH.value,
+                    public_address=sentinel.public_address_1,
+                ),
+                stub(
+                    network=sentinel.network,
+                    wallet_type=WalletType.ETH.value,
+                    public_address=sentinel.public_address_2,
+                ),
+                stub(
+                    network=sentinel.network,
+                    wallet_type=WalletType.ETH.value,
+                    public_address=sentinel.public_address_3,
+                ),
+            ],
+        ),
+        error_code=sentinel.error_code,
+        message=sentinel.message,
+        status=sentinel.status,
+    )
+
+    metadata_no_wallets = stub(
+        data=stub(
+            email=sentinel.email,
+            issuer=sentinel.issuer,
+            public_address=sentinel.public_address,
+        ),
+        error_code=sentinel.error_code,
+        message=sentinel.message,
+        status=sentinel.ok,
+    )
+
     @pytest.fixture(autouse=True)
     def setup(self):
         self.user = User()
+        self.user.Token = mock.Mock()
 
     @pytest.fixture
-    def mock_get_metadata_by_issuer(self):
-        with mock.patch.object(
-            self.user,
-            'get_metadata_by_issuer',
-        ) as mock_get_metadata_by_issuer:
-            yield mock_get_metadata_by_issuer
-
-    @pytest.fixture
-    def mock_logout_by_issuer(self):
-        with mock.patch.object(
-            self.user,
-            'logout_by_issuer',
-        ) as mock_logout_by_issuer:
-            yield mock_logout_by_issuer
-
-    @pytest.fixture
-    def mock_construct_issuer_with_public_address(self):
-        with mock.patch(
+    def mock_construct_issuer_with_public_address(self, mocker):
+        return mocker.patch(
             'magic_admin.resources.user.construct_issuer_with_public_address',
-        ) as mock_construct_issuer_with_public_address:
-            yield mock_construct_issuer_with_public_address
+            return_value=sentinel.public_address,
+        )
 
     def test_get_metadata_by_issuer(self):
-        with mock.patch.object(
-            self.user,
-            'request',
-        ) as mock_request:
-            assert self.user.get_metadata_by_issuer(issuer) == mock_request.return_value
+        self.user.get_metadata_by_issuer_and_wallet = mock.Mock(
+            return_value=self.metadata_no_wallets,
+        )
 
-        mock_request.assert_called_once_with(
+        assert self.user.get_metadata_by_issuer(
+            sentinel.issuer,
+        ) == self.metadata_no_wallets
+
+        self.user.get_metadata_by_issuer_and_wallet.assert_called_once_with(
+            sentinel.issuer,
+            WalletType.NONE,
+        )
+
+    def test_get_metadata_by_issuer_and_any_wallet(self):
+        self.user.request = mock.Mock(return_value=self.metadata_with_wallets)
+
+        assert self.user.get_metadata_by_issuer_and_wallet(
+            sentinel.issuer,
+            WalletType.ANY,
+        ) == self.metadata_with_wallets
+
+        self.user.request.assert_called_once_with(
             'get',
             self.user.v1_user_info,
-            params={'issuer': issuer},
+            params={
+                'issuer': sentinel.issuer,
+                'wallet_type': WalletType.ANY,
+            },
+        )
+
+    def test_get_metadata_by_token(self):
+        self.user.get_metadata_by_issuer = mock.Mock(return_value=self.metadata_no_wallets)
+
+        assert self.user.get_metadata_by_token(
+            future_did_token,
+        ) == self.user.get_metadata_by_issuer.return_value
+
+        self.user.Token.get_issuer.assert_called_once_with(future_did_token)
+        self.user.get_metadata_by_issuer.assert_called_once_with(
+            self.user.Token.get_issuer.return_value,
+        )
+
+    def test_get_metadata_by_token_and_any_wallet(self):
+        self.user.get_metadata_by_issuer_and_wallet = mock.Mock(
+            return_value=self.metadata_with_wallets,
+        )
+
+        assert self.user.get_metadata_by_token_and_wallet(
+            future_did_token,
+            WalletType.ANY,
+        ) == self.user.get_metadata_by_issuer_and_wallet.return_value
+
+        self.user.Token.get_issuer.assert_called_once_with(future_did_token)
+        self.user.get_metadata_by_issuer_and_wallet.assert_called_once_with(
+            self.user.Token.get_issuer.return_value,
+            WalletType.ANY,
         )
 
     def test_get_metadata_by_public_address(
         self,
-        mock_get_metadata_by_issuer,
         mock_construct_issuer_with_public_address,
     ):
+        self.user.get_metadata_by_issuer = mock.Mock(return_value=self.metadata_no_wallets)
+
         assert self.user.get_metadata_by_public_address(
-            public_address,
-        ) == mock_get_metadata_by_issuer.return_value
+            sentinel.public_address,
+        ) == self.user.get_metadata_by_issuer.return_value
 
         mock_construct_issuer_with_public_address.assert_called_once_with(
-            public_address,
+            sentinel.public_address,
         )
-        mock_get_metadata_by_issuer.assert_called_once_with(
+        self.user.get_metadata_by_issuer.assert_called_once_with(
             mock_construct_issuer_with_public_address.return_value,
         )
 
-    def test_get_metadata_by_token(self, mock_get_metadata_by_issuer):
-        self.user.Token = mock.Mock()
+    def test_get_metadata_by_public_address_and_any_wallet(
+        self,
+        mock_construct_issuer_with_public_address,
+    ):
+        self.user.get_metadata_by_issuer_and_wallet = mock.Mock(
+            return_value=self.metadata_with_wallets,
+        )
 
-        assert self.user.get_metadata_by_token(
-            future_did_token,
-        ) == mock_get_metadata_by_issuer.return_value
+        assert self.user.get_metadata_by_public_address_and_wallet(
+            sentinel.public_address,
+            WalletType.ANY,
+        ) == self.user.get_metadata_by_issuer_and_wallet.return_value
 
-        self.user.Token.get_issuer.assert_called_once_with(future_did_token)
-        mock_get_metadata_by_issuer.assert_called_once_with(
-            self.user.Token.get_issuer.return_value,
+        mock_construct_issuer_with_public_address.assert_called_once_with(
+            sentinel.public_address,
+        )
+        self.user.get_metadata_by_issuer_and_wallet.assert_called_once_with(
+            mock_construct_issuer_with_public_address.return_value,
+            WalletType.ANY,
         )
 
     def test_logout_by_issuer(self):
-        with mock.patch.object(
-            self.user,
-            'request',
-        ) as mock_request:
-            assert self.user.logout_by_issuer(issuer) == mock_request.return_value
+        self.user.request = mock.Mock()
 
-        mock_request.assert_called_once_with(
+        assert self.user.logout_by_issuer(
+            sentinel.issuer,
+        )
+
+        self.user.request.assert_called_once_with(
             'post',
             self.user.v2_user_logout,
-            data={'issuer': issuer},
+            data={
+                'issuer': sentinel.issuer,
+            },
         )
 
     def test_logout_by_public_address(
         self,
-        mock_logout_by_issuer,
         mock_construct_issuer_with_public_address,
     ):
+        self.user.logout_by_issuer = mock.Mock()
+
         assert self.user.logout_by_public_address(
             public_address,
-        ) == mock_logout_by_issuer.return_value
+        ) == self.user.logout_by_issuer.return_value
 
         mock_construct_issuer_with_public_address.assert_called_once_with(
             public_address,
         )
-        mock_logout_by_issuer.assert_called_once_with(
+        self.user.logout_by_issuer.assert_called_once_with(
             mock_construct_issuer_with_public_address.return_value,
         )
 
-    def test_logout_by_token(self, mock_logout_by_issuer):
-        self.user.Token = mock.Mock()
+    def test_logout_by_token(self):
+        self.user.logout_by_issuer = mock.Mock()
 
         assert self.user.logout_by_token(
             future_did_token,
-        ) == mock_logout_by_issuer.return_value
+        ) == self.user.logout_by_issuer.return_value
 
         self.user.Token.get_issuer.assert_called_once_with(future_did_token)
-        mock_logout_by_issuer.assert_called_once_with(
+        self.user.logout_by_issuer.assert_called_once_with(
             self.user.Token.get_issuer.return_value,
         )


### PR DESCRIPTION
### 📦 Pull Request

The current implementation of magic-admin-php for metadata retrieval returns the Ethereum public_address.

We are adding functionality to query wallet(s) for any chain tied to the end-user.

Example (queries all Solana wallets created for the user if applicable):
`meta = magic.User.get_metadata_by_token_and_wallet(did_token, WalletType.SOLANA)`

Example (queries all wallets created for the user if applicable):
`meta = magic.User.get_metadata_by_token_and_wallet(did_token, WalletType.ANY)`

Please see supported wallet types in`magic_admin/resources/wallet.py`.

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

`make test`

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
