### PR TITLE
Add granularity for DID Token Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 - <PR-#ISSUE> ...
 
+## `0.2.0` - 1/04/2023
+
+#### Added
+
+- PR-#50: Split up DIDTokenError into DIDTokenExpired, DIDTokenMalformed, and DIDTokenInvalid.
+
 ## `0.1.0` - 11/30/2022
 
 #### Added

--- a/magic_admin/error.py
+++ b/magic_admin/error.py
@@ -21,6 +21,14 @@ class DIDTokenError(MagicError):
     pass
 
 
+class DIDTokenMalformed(MagicError):
+    pass
+
+
+class DIDTokenExpired(MagicError):
+    pass
+
+
 class APIConnectionError(MagicError):
     pass
 

--- a/magic_admin/error.py
+++ b/magic_admin/error.py
@@ -17,7 +17,7 @@ class MagicError(Exception):
         return {'message': str(self)}
 
 
-class DIDTokenError(MagicError):
+class DIDTokenInvalid(MagicError):
     pass
 
 

--- a/magic_admin/resources/token.py
+++ b/magic_admin/resources/token.py
@@ -142,9 +142,8 @@ class Token(ResourceComponent):
 
         if claim['ext'] is None:
             raise DIDTokenInvalid(
-                message='Given DID token cannot be used at this time. Please '
-                'check the "ext" field and regenerate a new token with a suitable '
-                'value.',
+                message='Please check the "ext" field and regenerate a new token '
+                'with a suitable value.',
             )
 
         recovered_address = w3.eth.account.recoverHash(

--- a/magic_admin/utils/did_token.py
+++ b/magic_admin/utils/did_token.py
@@ -1,4 +1,4 @@
-from magic_admin.error import DIDTokenError
+from magic_admin.error import DIDTokenMalformed
 
 
 def parse_public_address_from_issuer(issuer):
@@ -14,7 +14,7 @@ def parse_public_address_from_issuer(issuer):
     try:
         return issuer.split(':')[2]
     except IndexError:
-        raise DIDTokenError(
+        raise DIDTokenMalformed(
             'Given issuer ({}) is malformed. Please make sure it follows the '
             '`did:method-name:method-specific-id` format.'.format(issuer),
         )

--- a/tests/unit/error_test.py
+++ b/tests/unit/error_test.py
@@ -2,7 +2,7 @@ from magic_admin.error import APIConnectionError
 from magic_admin.error import APIError
 from magic_admin.error import AuthenticationError
 from magic_admin.error import BadRequestError
-from magic_admin.error import DIDTokenError
+from magic_admin.error import DIDTokenInvalid
 from magic_admin.error import ForbiddenError
 from magic_admin.error import MagicError
 from magic_admin.error import RateLimitingError
@@ -34,9 +34,9 @@ class TestMagicError(MagicErrorBase):
     error_class = MagicError
 
 
-class TestDIDTokenError(MagicErrorBase):
+class TestDIDTokenInvalid(MagicErrorBase):
 
-    error_class = DIDTokenError
+    error_class = DIDTokenInvalid
 
 
 class TestAPIConnectionError(MagicErrorBase):

--- a/tests/unit/resources/token_test.py
+++ b/tests/unit/resources/token_test.py
@@ -257,9 +257,8 @@ class TestTokenValidate:
         with pytest.raises(DIDTokenInvalid) as e:
             Token.validate(self.did_token)
 
-        assert str(e.value) == 'Given DID token cannot be used at this time. ' \
-            'Please check the "ext" field and regenerate a new token with a ' \
-            'suitable value.'
+        assert str(e.value) == 'Please check the "ext" field and regenerate a new' \
+            ' token with a suitable value.'
 
     def test_validate_raises_error_if_did_token_used_before_nbf(self, setup_mocks):
         setup_mocks.epoch_time_now.return_value = \

--- a/tests/unit/utils/did_token_test.py
+++ b/tests/unit/utils/did_token_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from magic_admin.error import DIDTokenError
+from magic_admin.error import DIDTokenMalformed
 from magic_admin.utils.did_token import construct_issuer_with_public_address
 from magic_admin.utils.did_token import parse_public_address_from_issuer
 from testing.data.did_token import issuer
@@ -15,7 +15,7 @@ class TestDIDToken:
         assert parse_public_address_from_issuer(issuer) == public_address
 
     def test_parse_public_address_from_issuer_raises_error(self):
-        with pytest.raises(DIDTokenError) as e:
+        with pytest.raises(DIDTokenMalformed) as e:
             parse_public_address_from_issuer(self.malformed_issuer)
 
         assert str(e.value) == \


### PR DESCRIPTION
### 📦 Pull Request

The `DIDTokenError` is too vague so we split this up into `DIDTokenExpired`, `DIDTokenMalformed`, and `DIDTokenInvalid`.

`DIDTokenMalformed`: raised when DID token cannot be decoded or if required fields are missing
`DIDTokenExpired`: raised when current time > DID Token expiration time 
`DIDTokenInvalid`: raised when DID token can be decoded but does not pass validation (missing values, signature mismatch, etc.)

### 🗜 Versioning

(Check _one!_)

- [ ] Patch: Bug Fix?
- [x] Minor: New Feature?
- [ ] Major: Breaking Change?

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

Tests pass with `make test`.

### ⚠️ Update `CHANGELOG.md`

- [x] I have updated the `Upcoming Changes` section of `CHANGELOG.md` with context related to this Pull Request.
