### PR TITLE
feat: add remove_mfa_by_public_address to User resource

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     -   id: codespell
         exclude: ^locale/
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.18
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## `2.5.0` - 2026-06-19
+
+#### 🚀 New Features
+
+- **Added `remove_mfa_by_public_address` to the User resource**
+  - Lets developers remove (deactivate) all multi-factor authentication for one of their app's users, identified by the user's public address
+  - Useful for support flows where a user is locked out of their authenticator
+  - Example: `magic.User.remove_mfa_by_public_address("0x...")`
+  - The user must belong to the app associated with your secret key; otherwise the request is rejected
+
+---
+
 ## `2.4.0` - 2026-05-06
 
 #### 🚀 New Features

--- a/magic_admin/resources/user.py
+++ b/magic_admin/resources/user.py
@@ -7,6 +7,7 @@ class User(ResourceComponent):
     v1_user_info = "/v1/admin/user"
     v1_users_info = "/v1/admin/users"
     v1_user_logout = "/v1/admin/user/logout"
+    v1_user_remove_mfa = "/v1/admin/user/remove_mfa"
     v2_user_info = "/v2/admin/user"
 
     def get_metadata_by_email(self, email, provider=None):
@@ -66,3 +67,12 @@ class User(ResourceComponent):
 
     def logout_by_token(self, did_token):
         return self.logout_by_issuer(self.Token.get_issuer(did_token))
+
+    def remove_mfa_by_public_address(self, public_address):
+        return self.request(
+            "post",
+            self.v1_user_remove_mfa,
+            data={
+                "issuer": construct_issuer_with_public_address(public_address),
+            },
+        )

--- a/magic_admin/version.py
+++ b/magic_admin/version.py
@@ -1,1 +1,1 @@
-VERSION = "2.4.0"
+VERSION = "2.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "magic-admin"
-version = "2.4.0"
+version = "2.5.0"
 description = "Magic Python Library"
 readme = "README.md"
 authors = [

--- a/tests/unit/resources/user_test.py
+++ b/tests/unit/resources/user_test.py
@@ -7,6 +7,7 @@ from pretend import stub
 from magic_admin.resources.user import User
 from magic_admin.resources.wallet import WalletType
 from testing.data.did_token import future_did_token
+from testing.data.did_token import issuer
 from testing.data.did_token import public_address
 
 
@@ -262,4 +263,19 @@ class TestUser:
         self.user.Token.get_issuer.assert_called_once_with(future_did_token)
         self.user.logout_by_issuer.assert_called_once_with(
             self.user.Token.get_issuer.return_value,
+        )
+
+    def test_remove_mfa_by_public_address(self):
+        self.user.request = mock.Mock()
+
+        assert self.user.remove_mfa_by_public_address(
+            public_address,
+        )
+
+        self.user.request.assert_called_once_with(
+            "post",
+            self.user.v1_user_remove_mfa,
+            data={
+                "issuer": issuer,
+            },
         )


### PR DESCRIPTION
## Summary

Adds `User.remove_mfa_by_public_address(public_address)` to the Magic Python Admin SDK, letting developers remove (deactivate) all MFA for one of their app's users, identified by the user's public address. Useful for support flows where a user is locked out of their authenticator.

- New `User.remove_mfa_by_public_address(public_address)` method + `v1_user_remove_mfa = "/v1/admin/user/remove_mfa"` endpoint constant — mirrors the existing `logout_by_*` plumbing, deriving the issuer via the existing `construct_issuer_with_public_address` helper and POSTing `{"issuer": ...}`.
- Version bump `2.4.0` → `2.5.0` (`version.py` + `pyproject.toml`) and a `2.5.0` CHANGELOG entry.

## Dependency / rollout

> [!IMPORTANT]
> Do **not** publish/release the package until the toaster backend endpoint `POST /v1/admin/user/remove_mfa` is deployed. This PR is the SDK client side only; unit tests mock the request layer, so it builds and tests independently.

The user must belong to the app associated with the configured `X-Magic-Secret-Key`; otherwise the backend rejects the request.

## Test Plan

- [x] `test_remove_mfa_by_public_address` added — asserts the request is made to `v1_user_remove_mfa` with the real derived issuer
- [x] Full unit suite passes locally (112 passed, Python 3.11)
- [ ] CI tox matrix (py311/py312/py313) + lint green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)